### PR TITLE
changed calendar address to non-secure http

### DIFF
--- a/chatbot.js
+++ b/chatbot.js
@@ -66,7 +66,7 @@ exports.handleCalendar = function(event, room, toStartOfTimeline, client) {
               entry.end.toLocaleDateString('en-US', formattingOptions) +
               '\n'
           })
-          output += '\nFull Calendar: https://calendar.giveth.io'
+          output += '\nFull Calendar: http://calendar.giveth.io'
           sendMessage(output, user, client, roomId)
         } else {
           client.sendTextMessage(roomId, 'Something went wrong :(')


### PR DESCRIPTION
We use a forwarder to resolve calendar.giveth.io - a secure https link will throw a 404